### PR TITLE
chore: Add proper support for id segments in cli

### DIFF
--- a/IntoRdf/Public/Models/TransformationDetails.cs
+++ b/IntoRdf/Public/Models/TransformationDetails.cs
@@ -9,22 +9,11 @@ public class TransformationDetails
         OutputFormat = outputFormat;
         SourcePredicateBaseUri = predicateBaseUri;
         TargetPathSegments = targetPathSegments;
-        if (IdentifierSegment is not null)
-        {
-            IdentifierTargetPathSegment = IdentifierSegment;
-            if (targetPathSegments.Contains(IdentifierSegment))
-            {
-                throw new IntoRdfException("Same TargetPathSegment Object passed as both Identity and related Individual. A property cannot be described both as and Identity and a different Individual.");
-            }
-            if(targetPathSegments.Where(e => e.Equals(IdentifierSegment)).Count() > 0) {
-                throw new IntoRdfException("Equal TargetPathSegment objects passed as both Identity and related Individual. A property cannot be described both as and Identity and a different Individual.");
-            }
-        }
+        IdentifierTargetPathSegment = IdentifierSegment;
     }
     public Uri BaseUri { get; }
     public RdfFormat OutputFormat { get; }
     public Uri SourcePredicateBaseUri { get; }
     public List<TargetPathSegment> TargetPathSegments { get; }
     public TargetPathSegment? IdentifierTargetPathSegment { get; }
-
 }


### PR DESCRIPTION
Currently there where no way in the CLI of generating URLs of a non-id-column and still keep the GUID-default as id. Fixed this.

Example given excel:

| Tag No | Weight | Skidref |
|--------|--------|---------|
| 123    | 5      | 345     |
| 234    | 10     | 345     |
| 345    | 15     |         |

And command:

```
cat mel-test.xlsx | dotnet run --project IntoRdf.Cli -- -t 'Tag No:tag' -t 'skidref:tag'
```

we get:

```
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.

<http://example.com/66aef4b0-7709-4783-8daa-e02ea1f88356> <http://example.com/Tag%20No> <http://example.com/tag/123>;
                                                          <http://example.com/skidref> <http://example.com/tag/345>;
                                                          <http://example.com/weight> "5"^^xsd:string.
<http://example.com/ae5914ca-ccc3-467a-bfa5-ad0bbb5ee038> <http://example.com/Tag%20No> <http://example.com/tag/234>;
                                                          <http://example.com/skidref> <http://example.com/tag/345>;
                                                          <http://example.com/weight> "10"^^xsd:string.
<http://example.com/c2f8a3c3-eaea-41b4-bc97-6cd19b5eaf68> <http://example.com/Tag%20No> <http://example.com/tag/345>;
                                                          <http://example.com/skidref> <http://example.com/tag/>;
                                                          <http://example.com/weight> "15"^^xsd:string.
```