### PR TITLE
fix: remove BOM at the start of jsonld

### DIFF
--- a/IntoRdf/Utils/GraphSupportFunctions.cs
+++ b/IntoRdf/Utils/GraphSupportFunctions.cs
@@ -14,10 +14,10 @@ internal static class GraphSupportFunctions
         switch (writerType)
         {
             case RdfFormat.Trig:
-                graph.SaveToStream(new StreamWriter(outputStream, Encoding.UTF8), new TriGWriter());
+                graph.SaveToStream(new StreamWriter(outputStream, new UTF8Encoding(false)), new TriGWriter());
                 break;
             case RdfFormat.Jsonld:
-                graph.SaveToStream(new StreamWriter(outputStream, Encoding.UTF8), new JsonLdWriter());
+                graph.SaveToStream(new StreamWriter(outputStream, new UTF8Encoding(false)), new JsonLdWriter());
                 break;
             case RdfFormat.Turtle:
                 graph.SaveToStream(new StreamWriter(outputStream, new UTF8Encoding(false)), new CompressingTurtleWriter());


### PR DESCRIPTION
If output format is specified to be json-ld we wrote a UTF-8 BOM "EF BB BF", see https://en.wikipedia.org/wiki/Byte_order_mark. This causes problem when parsing rdf data in for example dotnetrdf. This commit removes BOM.

(This was already fixed for turtle)