### PR TITLE
fix: add option to custom escape certain chars

### DIFF
--- a/IntoRdf.Cli/TransformExcelCommand.cs
+++ b/IntoRdf.Cli/TransformExcelCommand.cs
@@ -41,9 +41,13 @@ internal class TransformExcelSettings : CommandSettings
     [CommandOption("-i |--identifier-segment")]
     public string? IdSegment { get; set; } = null;
 
-    [Description("A list of colon separated entries indicating target and url segment. Identifier column must be the first entry. For example -t 'SomeField:SomeField' -t 'SomeOtherField:SomeOtherField'")]
+    [Description("A list of colon separated entries indicating target and url segment. For example -t 'SomeField:SomeField' -t 'SomeOtherField:SomeOtherField'")]
     [CommandOption("-t |--target-path-segment")]
     public string[] TargetPathSegments { get; set; } = new string[0];
+
+    [Description("Do custom url encoding i.e. ² -> SQUARED', ³ -> CUBED, and ° -> DEGREES'")]
+    [CommandOption("-e |--encode")]
+    public bool CustomEncoding { get; set; } = false;
 }
 
 internal class TransformExcelCommand : Command<TransformExcelSettings>
@@ -61,12 +65,23 @@ internal class TransformExcelCommand : Command<TransformExcelSettings>
                 .Select(raw => GetSegment(raw, "--target-path-segment"))
                 .ToList();
 
+        var CustomEncoding = settings.TargetPathSegments
+            .Select(raw => GetCustomEncoding(raw, "--encode"))
+            .ToDictionary((pair) => pair.Key, (pair) => pair.Value);
+
+        var customEncoding = new Dictionary<string, string> {
+                {"\u00b2", "SQUARED" },
+                {"\u00b3", "CUBED" },
+                {"\u00b0", "DEGREES" },
+            };
+
         var transformationDetails = new TransformationDetails(
             new Uri(settings.BaseUri),
             new Uri(settings.BaseUri),
             idSegment,
             segments.ToList(),
-            settings.OutputFormat
+            settings.OutputFormat,
+            settings.CustomEncoding ? customEncoding : null
         );
 
         var inputStream = Console.OpenStandardInput();
@@ -90,7 +105,7 @@ internal class TransformExcelCommand : Command<TransformExcelSettings>
         return 0;
     }
 
-     private static string HandleCsv(TransformExcelSettings settings, TransformationDetails transformationDetails, Stream inputStream, TransformerService transformer)
+    private static string HandleCsv(TransformExcelSettings settings, TransformationDetails transformationDetails, Stream inputStream, TransformerService transformer)
     {
         var csvDetails = new CsvDetails();
         return transformer.TransformCsv(csvDetails, transformationDetails, inputStream);
@@ -125,5 +140,15 @@ internal class TransformExcelCommand : Command<TransformExcelSettings>
             throw new Exception($"Expected a ':' in {paramNameForDebug}");
         }
         return new TargetPathSegment(split[0], split[1]);
+    }
+
+    private static KeyValuePair<string, string> GetCustomEncoding(string encoding, string paramNameForDebug)
+    {
+        var split = encoding.Split(":");
+        if (split.Length != 2)
+        {
+            throw new Exception($"Expected a ':' in {paramNameForDebug}");
+        }
+        return new KeyValuePair<string, string>(split[0], split[1]);
     }
 }

--- a/IntoRdf/Public/Models/TransformationDetails.cs
+++ b/IntoRdf/Public/Models/TransformationDetails.cs
@@ -2,17 +2,33 @@ namespace IntoRdf.Models;
 
 public class TransformationDetails
 {
-    public TransformationDetails(Uri baseUri, Uri predicateBaseUri, TargetPathSegment? IdentifierSegment, List<TargetPathSegment> targetPathSegments, RdfFormat outputFormat)
+    public TransformationDetails(
+        Uri baseUri,
+        Uri predicateBaseUri,
+        TargetPathSegment? identifierSegment,
+        List<TargetPathSegment> targetPathSegments,
+        RdfFormat outputFormat,
+        IDictionary<string, string>? customEncoding = null)
     {
         BaseUri = baseUri;
         OutputFormat = outputFormat;
         SourcePredicateBaseUri = predicateBaseUri;
         TargetPathSegments = targetPathSegments;
-        IdentifierTargetPathSegment = IdentifierSegment;
+        IdentifierTargetPathSegment = identifierSegment;
+        CustomEncoding = customEncoding ?? new Dictionary<string, string>();
+
     }
     public Uri BaseUri { get; }
     public RdfFormat OutputFormat { get; }
     public Uri SourcePredicateBaseUri { get; }
     public List<TargetPathSegment> TargetPathSegments { get; }
     public TargetPathSegment? IdentifierTargetPathSegment { get; }
+
+    /// <summary>
+    /// A list of key values that will cause key-pattern to be replaced with values all places where these patterns are found before creating Uris.
+    /// This can be used to mitigate some encoding bugs in dotnetRDF
+    /// For example:
+    /// {"²", "squared"}
+    /// </summary>
+    public IDictionary<string, string> CustomEncoding { get; }
 }


### PR DESCRIPTION
We are struggling with some characters that create problems on serialization in into-rdf and then deserialization using dotnetrdf somewhere else. Fastest solution is to avoid these characters all together. Current problems can be mitigated using the following parameters:

```
var customEncoding = new Dictionary<string, string> {
    {"\u00b2", "SQUARED" },
    {"\u00b3", "CUBED" },
    {"\u00b0", "DEGREES" },
};
```