### PR TITLE
Downgrade DocumentFormat.OpenXml

### DIFF
--- a/IntoRdf/IntoRdf.csproj
+++ b/IntoRdf/IntoRdf.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.1.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
     <PackageReference Include="dotnetRDF" Version="3.2.1" />
 	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />


### PR DESCRIPTION
`DocumentFormat.OpenXml` v3.1.0 was causing Snyk tests to fail, so downgraded to v3.0.2 again