### PR TITLE
feat: support custom predicates

### DIFF
--- a/src/IntoRdf.Tests/BasicTests.cs
+++ b/src/IntoRdf.Tests/BasicTests.cs
@@ -1,6 +1,7 @@
 ﻿using IntoRdf.Models;
 using System;
 using System.Collections.Generic;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace IntoRdf.Tests;
@@ -10,15 +11,23 @@ public class BasicTests
     private static readonly Uri DataUri = new Uri("https://rdf.equinor.com/");
     private static readonly Uri PredicateUri = new Uri("https://rdf.equinor.com/source/mel#");
     private const string SheetName = "sheetName";
+    private const string RdfsLabel = "http://www.w3.org/2000/01/rdfschema#label";
 
-    private readonly RdfTestUtil rdfTestUtils = new RdfTestUtil("TestData/basic.xlsx", CreateSpreadsheetDetails(), CreateTransformationDetails());
 
 
     [Fact]
     public void NoTrailingSlash()
     {
+        RdfTestUtil rdfTestUtils = new RdfTestUtil("TestData/basic.xlsx", CreateSpreadsheetDetails(), CreateTransformationDetails());
         var subjects = rdfTestUtils.GetAllSubjects();
         Assert.All(subjects, (subject) => Assert.False(subject.EndsWith('/')));
+    }
+
+    [Fact]
+    public void CreateRdfsLabel()
+    {
+        RdfTestUtil rdfTestUtils = new RdfTestUtil("TestData/basic.xlsx", CreateSpreadsheetDetails(), CreateLabelTransformationDetails());
+        rdfTestUtils.AssertObjectExist(new Dictionary<string, object> {{RdfsLabel, "Donatello"}}, true);
     }
 
     private static SpreadsheetDetails CreateSpreadsheetDetails()
@@ -28,10 +37,12 @@ public class BasicTests
 
     private static TransformationDetails CreateTransformationDetails()
     {
-        return new TransformationDetails(DataUri,
-         PredicateUri,
-         null,
-         new List<TargetPathSegment>()
-            , RdfFormat.Turtle);
+        return new TransformationDetails(DataUri, PredicateUri, null, [], RdfFormat.Turtle);
+    }
+
+    private static TransformationDetails CreateLabelTransformationDetails()
+    {
+        var rdfsLabelConfig = new TargetPathSegment ("Name", null, RdfsLabel);
+        return new TransformationDetails(DataUri, PredicateUri, null, [rdfsLabelConfig], RdfFormat.Turtle);
     }
 }

--- a/src/IntoRdf.Tests/RdfTestUtil.cs
+++ b/src/IntoRdf.Tests/RdfTestUtil.cs
@@ -95,13 +95,17 @@ namespace IntoRdf.Tests
             Assert.True(ok, errorMsg);
         }
 
-        internal void AssertObjectExist(Dictionary<string, object> expectedProps)
+        internal void AssertObjectExist(Dictionary<string, object> expectedProps, bool acceptExtraProps = false)
         {
             var subjects = GetSubjects(expectedProps);
             var debugMsg = $"Expected to find a single object, but found {subjects.Count} objects satisfing the predicate-object pairs: [\n{DebugProps(expectedProps, 2)}\n]";
             if (subjects.Count != 1)
             {
                 Assert.Fail(debugMsg);
+            }
+
+            if (acceptExtraProps) {
+                return;
             }
 
             var expectedPropCount = expectedProps.Count + 1; //Add prop for WasGeneratedBy property

--- a/src/IntoRdf/Public/Models/TargetPathSegment.cs
+++ b/src/IntoRdf/Public/Models/TargetPathSegment.cs
@@ -1,32 +1,45 @@
 namespace IntoRdf.Models;
 
 ///<summary>
-///Class to aid in the creation of RDF individuals from literals
+///Class to aid in the creation of RDF individuals from literals. Should probably be renamed to ColumnConfiuration, but is kept for now to avoid breaking changes
 ///</summary>
 public class TargetPathSegment : IEquatable<TargetPathSegment>
 {
-    ///<summary> 
-    ///Target is the property name of the literal to turn into an individual. 
-    ///When transforming a spreadsheet this will typically refer to a column name 
+    ///<summary>
+    ///Target is the property name of the literal to turn into an individual.
+    ///When transforming a spreadsheet this will typically refer to a column name
     ///</summary>
     public string Target { get; }
     ///<summary>
-    ///The UriSegment is appended to the base uri, to enable the creation of specific namespaces for different individuals.
+    /// PredicateUri will will be used to create the RDF Predicate
+    //////<summary>
+    public string? PredicateUri { get; }
+    ///<summary>
+    ///The UriSegment is appended to the base uri, to enable the creation of specific namespaces for different RDF Objects.
     ///For instance: http://example.com (baseUri) + animal (uriSegment) + MyDog (from data) returns http://example.com/animal/MyDog
     ///<summary>
-    public string UriSegment { get; }
-    public TargetPathSegment(string target, string segment)
+    public string? UriSegment { get; }
+
+    public TargetPathSegment(string target, string? segment, string? predicateUri = null)
     {
         Target = target;
         UriSegment = segment;
+        PredicateUri = predicateUri;
     }
 
     public bool Equals(TargetPathSegment? other)
     {
-        if (other is not null && this.Target.Equals(other.Target, StringComparison.InvariantCultureIgnoreCase) && this.UriSegment.Equals(other.UriSegment, StringComparison.InvariantCultureIgnoreCase))
-        {
-            return true;
-        }
-        return false;
+        if (other is null) return false;
+
+        return
+            StringEqual(Target, other.Target) &&
+            StringEqual(UriSegment, other.UriSegment) &&
+            StringEqual(PredicateUri, other.PredicateUri);
+    }
+
+    private static bool StringEqual(string? first, string? second) {
+        if (first == null && second == null) return true;
+        if (first == null) return false;
+        return first.Equals(second, StringComparison.InvariantCultureIgnoreCase);
     }
 }


### PR DESCRIPTION
We would like to make some of the columns in a spreadsheet rdfs:label or skos:definition. More generally we would like to specify a completely custom predicate for a given column name as opposed to being limited to a common prefix for an entire excel sheet / table.

Tried my best to be backward compatible, but will probably suggest some renaming / refactoring in a future PR. TargetPathSegment in particular is now a misleading name. I also find it confusing which config values are controlling the predicate and which are controlling the object of the transformation of a given cell into an RDF triple